### PR TITLE
Up timeout for PDF export

### DIFF
--- a/.github/workflows/run-addon.yml
+++ b/.github/workflows/run-addon.yml
@@ -5,3 +5,5 @@ on: repository_dispatch
 jobs:
   Run-Add-On:
     uses: MuckRock/documentcloud-addon-workflows/.github/workflows/run-addon.yml@v1
+    with:
+      timeout: 120


### PR DESCRIPTION
I'm bumping PDF export from 5 minute (default) timeout to 2 hours (120) so that users can bulk export their projects for safekeeping.